### PR TITLE
Bump NUnit.Analyzers from 4.0.1 to 4.1.0

### DIFF
--- a/LoadModules.Extensions.Tests/LoadModules.Extensions.Tests.csproj
+++ b/LoadModules.Extensions.Tests/LoadModules.Extensions.Tests.csproj
@@ -23,7 +23,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs" Link="SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Manually rebuilt version of Dependabot #95 without mangling RDMP inclusion.